### PR TITLE
Fix RPG.py

### DIFF
--- a/RPG.py
+++ b/RPG.py
@@ -229,8 +229,7 @@ if __name__ == "__main__":
         elif use_local:
             appendix='local'
         initialize(model_name=model_name)
-        image=RPG
-        (
+        image=RPG(
         user_prompt=user_prompt,
         diffusion_model=model_name,
         version=version,


### PR DESCRIPTION
commit e37e60c broke inference:
```
  File "/mnt/minerva1/nlp/projects/text2video/RPG-DiffusionMaster/RPG.py", line 234
    user_prompt=user_prompt,
    ^^^^^^^^^^^^^^^^^^^^^^^
SyntaxError: invalid syntax. Maybe you meant '==' or ':=' instead of '='?
```